### PR TITLE
fix(ci): pass base-href via dedicated script to fix demo deploy

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -30,7 +30,11 @@ jobs:
         run: pnpm run build:lib
 
       - name: Build demo app
-        run: pnpm run build:demo -- --base-href=/ngx-mat-tiptap/
+        # Use a dedicated script rather than `pnpm run build:demo -- --base-href=...`:
+        # pnpm@9.x forwards the bare `--` to Angular's CLI as an empty positional
+        # argument, which fails schema validation. Baking the flag into the script
+        # avoids passing `--` through pnpm entirely.
+        run: pnpm run build:demo:ghpages
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "ng serve",
     "build": "ng build",
     "build:demo": "ng build demo",
+    "build:demo:ghpages": "ng build demo --base-href=/ngx-mat-tiptap/",
     "build:lib": "ng build ngx-mat-tiptap && node -e \"const fs = require('fs'); const path = 'dist/ngx-mat-tiptap'; fs.writeFileSync(path + '/index.d.ts', 'export * from \\\"./types/felixdulfer-ngx-mat-tiptap\\\";\\n'); const pkg = JSON.parse(fs.readFileSync(path + '/package.json', 'utf8')); if (pkg.exports && pkg.exports['.']) { pkg.exports['.'].types = './index.d.ts'; delete pkg.typings; fs.writeFileSync(path + '/package.json', JSON.stringify(pkg, null, 2) + '\\n'); }\"",
     "build:lib:watch": "ng build ngx-mat-tiptap --watch",
     "watch": "ng build --watch --configuration development",


### PR DESCRIPTION
The deploy-demo workflow ran `pnpm run build:demo -- --base-href=...`,
but pnpm@9.x forwards the bare `--` to Angular's CLI as an empty
positional argument, causing a schema validation failure:

  Error: Schema validation failed with the following errors:
    Data path "" must NOT have additional properties().

Add a dedicated `build:demo:ghpages` script that bakes in the base-href
so no `--` needs to be passed through pnpm, and call it from the
workflow. This is consistent with the existing pnpm@9.x `--` workaround
already documented in jest.yml.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FYrtmNTvanZTTxc8PETa76